### PR TITLE
add Pointer-Events to "Properties on hover"

### DIFF
--- a/Snippets/Properties on hover.md
+++ b/Snippets/Properties on hover.md
@@ -20,10 +20,12 @@ source: https://discord.com/channels/686053708261228577/702656734631821413/11442
 .metadata-properties-title {
   transition: 500ms;
   opacity: 0.2;
+  pointer-events: none;
 }
 .metadata-container:hover .metadata-properties-title {
   opacity: 1;
   color: var(--text-accent);
+  pointer-events: auto;
 }
 
 .metadata-content {
@@ -31,10 +33,12 @@ source: https://discord.com/channels/686053708261228577/702656734631821413/11442
   opacity: 0;
   height: 0;
   margin-bottom: -1.8em;
+  pointer-events: none;
 }
 .metadata-container:hover .metadata-content {
   opacity: 1;
   height: auto;
   margin-bottom: 0.5em;
+  pointer-events: auto;
 }
 ```


### PR DESCRIPTION
adds pointer events so the hover part of the snippet doesn't interfere with other clickable objects

(without this change metadata-content would be displayed upon hovering over it, even if it was hidden.
This would interfere with for example other snippets/plugins that have clickable elements directly under properties)